### PR TITLE
Re-write entire css file every macro expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ pom.xml.asc
 node_modules
 .cljs_node_repl
 *.log
+resources/public/main.css

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -3,6 +3,7 @@
     <head>
         <title>om-css</title>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <link href="main.css" rel="stylesheet" type="text/css">
     </head>
     <body>
         <script src="main.js" type="text/javascript"></script>

--- a/scripts/figwheel.clj
+++ b/scripts/figwheel.clj
@@ -2,7 +2,7 @@
          '[figwheel-sidecar.repl-api :as ra])
 
 (ra/start-figwheel!
-  {:figwheel-options {}
+  {:figwheel-options {:css-dirs ["resources/public"]}
    :build-ids ["devcards"]
    :all-builds
    [{:id "devcards"


### PR DESCRIPTION
While slower on initial compilation we need to re-write the css file to
make the figwheel workflow be correct. Appending the new css each change
is incorrect when we delete a selector as the old selector will cascade
down.

The theoretically optimal way to do this would be to append to file when
we are adding components but re-write the component when there are
changes. This would be performant for both initial compilation and small
changes. However, this is complicated and we should keep the simple and
correct thing until we feel the pain from a slow initial build.
