### PR TITLE
Don't convert ref to string

### DIFF
--- a/src/main/om_css/dom.cljc
+++ b/src/main/om_css/dom.cljc
@@ -71,7 +71,7 @@
     :else opt-val))
 
 (defn- format-attrs [attrs]
-  "Leaves :className unchanged, formats :class accordingly. Converts :ref to string."
+  "Leaves :className unchanged, formats :class accordingly."
   (let [map #?(:clj  clojure.core/map
                :cljs cljs.core/map)]
     (->> attrs
@@ -83,9 +83,6 @@
              (let [component-info (:omcss$info attrs)
                    classes-seen (:classes component-info)]
                (utils/format-dom-class-names v component-info classes-seen))
-
-             :ref
-             (str v)
 
              (format-opt-val v))]))
       (reduce (fn [m [k v]]


### PR DESCRIPTION
Refs should be functions in react, so removed the conversion of ref to string.